### PR TITLE
Tetragon nix pkgs for ghaf

### DIFF
--- a/modules/graphics/demo-apps.nix
+++ b/modules/graphics/demo-apps.nix
@@ -36,7 +36,8 @@
 in {
   options.ghaf.graphics.demo-apps = with lib; {
     chromium = mkProgramOption "Chromium browser" false;
-    firefox = mkProgramOption "Firefox browser" weston.enableDemoApplications;
+    firefox = mkProgramOption "Firefox browser" false;
+#    firefox = mkProgramOption "Firefox browser" weston.enableDemoApplications;
     gala-app = mkProgramOption "Gala App" false;
     element-desktop = mkProgramOption "Element desktop" weston.enableDemoApplications;
     zathura = mkProgramOption "zathura" weston.enableDemoApplications;

--- a/modules/host/default.nix
+++ b/modules/host/default.nix
@@ -22,6 +22,9 @@
   ];
 
   config = {
+    ghaf = {
+      policy.tetragon.enable = true;
+    };
     networking.hostName = "ghaf-host";
     system.stateVersion = lib.trivial.release;
 

--- a/modules/policy/clients/tetragon.nix
+++ b/modules/policy/clients/tetragon.nix
@@ -31,7 +31,7 @@ in
           User = "root";
           Group = "root";
           Environment="PATH=${pkgs.tetragon}/lib/tetragon/:${pkgs.tetragon}/lib:${pkgs.tetragon}/bin";
-          ExecStart = "${pkgs.tetragon}/bin/tetragon";
+          ExecStart = "${pkgs.tetragon}/bin/tetragon --bpf-lib ${pkgs.tetragon}/lib/tetragon/bpf --server-address 0.0.0.0:3333 ";
           StartLimitBurst = 10;
           StartLimitIntervalSec = 120;
         };
@@ -41,9 +41,10 @@ in
         tetragon.source = "${pkgs.tetragon}/lib/tetragon/";
       };
 
-      # networking = {
-      #   firewall.allowedTCPPorts = [ 123 ];
-      # };
+      environment.systemPackages = with pkgs; [tetragon];
+       networking = {
+         firewall.allowedTCPPorts = [ 3333 ];
+       };
 
     };
 

--- a/modules/virtualization/microvm/adminvm.nix
+++ b/modules/virtualization/microvm/adminvm.nix
@@ -29,6 +29,8 @@
         nixpkgs.buildPlatform.system = configHost.nixpkgs.buildPlatform.system;
         nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
 
+        environment.systemPackages = with pkgs; [tetragon];
+
         systemd.network = {
           enable = true;
           networks."10-ethint0" = {

--- a/targets/generic-x86_64.nix
+++ b/targets/generic-x86_64.nix
@@ -39,6 +39,7 @@
           ../modules/host
           ../modules/virtualization/microvm/microvm-host.nix
           ../modules/virtualization/microvm/netvm.nix
+          ../modules/virtualization/microvm/adminvm.nix
           {
             ghaf = {
               hardware.x86_64.common.enable = true;
@@ -49,6 +50,8 @@
                 enable = true;
                 extraModules = netvmExtraModules;
               };
+
+              virtualization.microvm.adminvm.enable = true;
 
               # Enable all the default UI applications
               profiles = {

--- a/targets/vm.nix
+++ b/targets/vm.nix
@@ -33,7 +33,7 @@
 
               # Enable all the default UI applications
               profiles = {
-                applications.enable = false;
+                applications.enable = true;
                 #TODO clean this up when the microvm is updated to latest
                 release.enable = variant == "release";
                 debug.enable = variant == "debug";


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->
Packaging Tetragon into the Ghaf platform:

1. Excluded pre-compiled Tetragon binaries from the Nix package and enabled compilation from the source code available on GitHub.
2. Addressed Docker dependencies in the Nix build environment.
3. Investigated and addressed Clang Compiler warnings and errors related to Tetragon eBPF, ensuring the successful testing of functionalities.

Please review the changes and merge into your branch

<!--EndFragment-->
</body>
</html>